### PR TITLE
added NoFocusOnAppearing to roll and loot windows

### DIFF
--- a/src/Kapture/Kapture/UserInterface/LootWindow.cs
+++ b/src/Kapture/Kapture/UserInterface/LootWindow.cs
@@ -19,7 +19,7 @@ namespace Kapture
         /// </summary>
         /// <param name="plugin">plugin.</param>
         public LootWindow(KapturePlugin plugin)
-            : base(plugin, Loc.Localize("LootOverlayWindow", "Loot") + "###Kapture_Loot_Window")
+            : base(plugin, Loc.Localize("LootOverlayWindow", "Loot") + "###Kapture_Loot_Window", ImGuiWindowFlags.NoFocusOnAppearing)
         {
             this.plugin = plugin;
         }

--- a/src/Kapture/Kapture/UserInterface/RollWindow.cs
+++ b/src/Kapture/Kapture/UserInterface/RollWindow.cs
@@ -19,7 +19,7 @@ namespace Kapture
         /// </summary>
         /// <param name="plugin">plugin.</param>
         public RollWindow(KapturePlugin plugin)
-            : base(plugin, Loc.Localize("RollMonitorOverlayWindow", "Roll Monitor") + "###Kapture_RollMonitor_Window")
+            : base(plugin, Loc.Localize("RollMonitorOverlayWindow", "Roll Monitor") + "###Kapture_RollMonitor_Window", ImGuiWindowFlags.NoFocusOnAppearing)
         {
             this.plugin = plugin;
         }


### PR DESCRIPTION
Currently the roll and loot focus from other windows when they appear. Since both of then are only displaying information to the player and require no input they should not get focused when they are created. This leads to weird situations where focus is stolen from other plugins (like chat plugins) when a lot chest is opened.